### PR TITLE
Implements a deploy task

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,11 @@
-Concourse Tasks for OutSystems
+# Concourse Tasks for OutSystems
+
+## Tasks
+
+See comments in the [task definitions](tasks) for an explanation of the parameters 
+to each task.
+
+### `deploy`
+
+Deploys an outsystems application from one environment to another
+

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -1,0 +1,32 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: ghcr.io/crdant/outsystems-pipeline-resource
+
+inputs:
+- name: artifacts
+
+outputs:
+- name: artifacts
+
+params:
+  LIFETIME_URL:
+  LIFETIME_TOKEN:
+  API_VERSION: 
+  SOURCE:
+  DESTINATION:
+  APPLICATIONS:
+  MESSAGE:
+
+run:
+  path: bash
+  args:
+  - -c | 
+    
+    python3 -m outsystems.pipeline.deploy_latest_tags_to_target_env --artifacts artifacts \
+      --lt_url "${LIFETIME_URL}" --lt_token "${LIFETIME_TOKEN}" --lt_api_version "${API_VERSION}" \
+      --source_env "${SOURCE}" --destination_env "${DESTINATION}" --app_list "${APPLICATIONS}" \
+      --deploy_msg "${MESSAGE}"

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -49,7 +49,7 @@ run:
       MESSAGE="Automated deploymend triggered by pipeline on ${HOSTNAME} on $(date)"
     fi 
 
-    pythpon3 -m outsystems.pipeline.deploy_latest_tags_to_target_env --artifacts artifacts \
+    python3 -m outsystems.pipeline.deploy_latest_tags_to_target_env --artifacts artifacts \
       --lt_url "${LIFETIME_URL}" --lt_token "${LIFETIME_TOKEN}" --lt_api_version "${API_VERSION}" \
       --source_env "${SOURCE}" --destination_env "${DESTINATION}" --app_list "${APPLICATIONS}" \
       --deploy_msg "${MESSAGE}"

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -45,8 +45,11 @@ run:
   args:
   - -c 
   - | 
-    
-    python3 -m outsystems.pipeline.deploy_latest_tags_to_target_env --artifacts artifacts \
+    if [[ -z "${MESSAGE}" ]] ; then
+      MESSAGE="Automated deploymend triggered by pipeline on ${HOSTNAME} on $(date)"
+    fi 
+
+    pythpon3 -m outsystems.pipeline.deploy_latest_tags_to_target_env --artifacts artifacts \
       --lt_url "${LIFETIME_URL}" --lt_token "${LIFETIME_TOKEN}" --lt_api_version "${API_VERSION}" \
       --source_env "${SOURCE}" --destination_env "${DESTINATION}" --app_list "${APPLICATIONS}" \
       --deploy_msg "${MESSAGE}"

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -13,13 +13,32 @@ outputs:
 - name: artifacts
 
 params:
-  LIFETIME_URL:
-  LIFETIME_TOKEN:
-  API_VERSION: 2
-  SOURCE:
-  DESTINATION:
   APPLICATIONS:
+  # - Required
+  # - A comma separated list of applications to deploy as part of the deployment
+  SOURCE:
+  # - Required
+  # - The source environment with the application already deployed, either from a 
+  #   previous deployment or directly from Service Studio
+  DESTINATION:
+  # - Required
+  # - The destination environment for the deployment
   MESSAGE:
+  # - Optional
+  # - A message to log alongside the deployment, if it is not provided the task 
+  #   will provide a prepared message with information about the Concourse job
+  #   responsible for the deployment
+  LIFETIME_URL:
+  # - Required
+  # - URL for the Lifetime server that will execute the deployment
+  LIFETIME_TOKEN:
+  # - Required
+  # - API token for a service account on the lifetime server that has admininstrator
+  #   rights in order to drive the deployment
+  API_VERSION: 2
+  # - Optional
+  # - Specifies the API version to use when accessing LifeTime, the default is
+  #   version 2 for OutSystems 11
 
 run:
   path: bash

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: ghcr.io/crdant/outsystems-pipeline-resource
+    repository: ghcr.io/crdant/outsystems-pipeline-image
 
 inputs:
 - name: artifacts
@@ -15,7 +15,7 @@ outputs:
 params:
   LIFETIME_URL:
   LIFETIME_TOKEN:
-  API_VERSION: 
+  API_VERSION: 2
   SOURCE:
   DESTINATION:
   APPLICATIONS:
@@ -24,7 +24,8 @@ params:
 run:
   path: bash
   args:
-  - -c | 
+  - -c 
+  - | 
     
     python3 -m outsystems.pipeline.deploy_latest_tags_to_target_env --artifacts artifacts \
       --lt_url "${LIFETIME_URL}" --lt_token "${LIFETIME_TOKEN}" --lt_api_version "${API_VERSION}" \

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -46,7 +46,7 @@ run:
   - -c 
   - | 
     if [[ -z "${MESSAGE}" ]] ; then
-      MESSAGE="Automated deploymend triggered by pipeline on ${HOSTNAME} on $(date)"
+      MESSAGE="Automated deploymend triggered by pipeline from concourse worker ${HOSTNAME} on $(date)"
     fi 
 
     python3 -m outsystems.pipeline.deploy_latest_tags_to_target_env --artifacts artifacts \


### PR DESCRIPTION
TL;DR
-----

Implements a basic deploy task

Details
-------

Uses the default `deploy_latest_tags_to_target_env` module from [`outsystems-pipeline`](https://github.com/OutSystems/outsystems-pipeline) to implement a basic deploy task. The task parameters are based on the expected command-line arguments when invoking that module, following the model from the example script in that repository.
